### PR TITLE
style: changed message text to match JS tutorial

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,14 +16,14 @@ def handle_sample_function_event(inputs: dict, say: Say, fail: Fail, logger: log
     try:
         say(
             channel=user_id,  # sending a DM to this user
-            text="Click button to complete function!",
+            text="Click the button to signal the function has completed",
             blocks=[
                 {
                     "type": "section",
-                    "text": {"type": "mrkdwn", "text": "Click button to complete function!"},
+                    "text": {"type": "mrkdwn", "text": "Click the button to signal the function has completed"},
                     "accessory": {
                         "type": "button",
-                        "text": {"type": "plain_text", "text": "Click me!"},
+                        "text": {"type": "plain_text", "text": "Complete function"},
                         "action_id": "sample_click",
                     },
                 }


### PR DESCRIPTION
### Summary

The API site uses the screenshots from the JS tutorial for this app's tutorial. I changed the text in this tutorial to match the JS tutorial so we can reuse the workflow builder screenshots.

### Requirements

- [X] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [X] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
- [X] I asked @zimeg all my silly questions
