### PR TITLE
fix: remove the outgoing domains property from the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,6 @@
   "display_information": {
     "name": "BoltPy Automation Template"
   },
-  "outgoing_domains": [],
   "settings": {
     "org_deploy_enabled": true,
     "socket_mode_enabled": true


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR removes the `outgoing_domains` property from the `manifest.json` since this is not enforced at an application level and the CLI now supports installing apps without this property set.

### Reviewers

```
$ slack create asdf --template slack-samples/bolt-python-custom-function-template
$ cd asdf
$ slack run
```

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
