### PR TITLE
fix: match manifest values used in other custom function templates

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
         "user_id": {
           "type": "slack#/types/user_id",
           "title": "User",
-          "description": "Send this to who?",
+          "description": "Message recipient",
           "is_required": true,
           "hint": "Select a user in the workspace",
           "name": "user_id"
@@ -37,7 +37,7 @@
         "user_id": {
           "type": "slack#/types/user_id",
           "title": "User",
-          "description": "User to used the function",
+          "description": "User that completed the function",
           "is_required": true,
           "name": "user_id"
         }


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR matches `manifest.json` to those found in [slack-samples/bolt-js-custom-function-template](https://github.com/slack-samples/bolt-js-custom-function-template/blob/main/manifest.json)! Thanks for finding strangeness here @srtaalej 🎉 

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
