### PR TITLE
feat: add function_runtime to the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,8 @@
   },
   "settings": {
     "org_deploy_enabled": true,
-    "socket_mode_enabled": true
+    "socket_mode_enabled": true,
+    "function_runtime": "remote"
   },
   "features": {
     "bot_user": {


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation
- [x] Other

### Summary

function_runtime will shortly be a required property when an app manifest contains functions. 
Setting this to `remote` which should be set for all non ROSI hosting scenarios.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
