### PR TITLE
fix: include the function_executed event in subscribed bot events

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,9 @@
     "name": "BoltPy Automation Template"
   },
   "settings": {
+    "event_subscriptions": {
+      "bot_events": ["function_executed"]
+    },
     "org_deploy_enabled": true,
     "socket_mode_enabled": true,
     "function_runtime": "remote"


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR includes `function_executed` as a subscribed bot event to avoid manifest validation errors.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
